### PR TITLE
Update Basic Authentication for public gists

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,21 @@ a commandline gister in golang
 
 > This is a port of [gist](https://github.com/defunkt/gist) in Go
 
+## Settings
+
+1. [Create a personal access token] https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
+
+2. Set the `GITHUB_TOKEN` environment variable to the value `username:token`,
+   or write `usernmae:token` to `~/.gist` file.
+
 ## Usage
 
 1. Get the pre-built Linux (x86_64) built or download and build it yourself.
 
 `gister` provides 3 optional CLI arguments.
-  - `-p`: If `true`, the gist created will be public. Defaults to `true`.
+  - `-public`: If `true`, the gist created will be public. Defaults to `true`.
   - `-d`: Provide a description. Defaults to `This is a gist`.
-  - `-a`: If `true`, the gist created will be anonymous. Set `false` to create a gist for a user. Defaults to `true`.
+  - `-anonymous`: If `true`, the gist created will be anonymous. Set `false` to create a gist for a user. Defaults to `true`.
 
 2. Running `gister --h` for the available options and usage.
 

--- a/gister.go
+++ b/gister.go
@@ -43,6 +43,7 @@ const (
 
 //User agent defines a custom agent (required by GitHub)
 //`token` stores the GITHUB_TOKEN from the env variables
+// GITHUB_TOKEN must be in format of `username:token`
 var (
 	USER_AGENT = "gist/" + VERSION
 	token      = os.Getenv("GITHUB_TOKEN")
@@ -154,6 +155,9 @@ func main() {
 		post_to += "/" + update
 	}
 	req, err := http.NewRequest("POST", post_to, b)
+	if err != nil {
+		log.Fatal("Cannot create request: ", err)
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -161,7 +165,11 @@ func main() {
 		if token == "" {
 			token = loadTokenFromFile()
 		}
-		req.SetBasicAuth(token, "x-oauth-basic")
+		words := strings.Split(token, ":")
+		if len(words) != 2 {
+			log.Fatalf("token must be in form `username:token`, was actually %s", token)
+		}
+		req.SetBasicAuth(words[0], words[1])
 	}
 
 	client := http.Client{}


### PR DESCRIPTION
According to
https://developer.github.com/v3/auth/#basic-authentication
the github username and a personal access token are needed now.

Without this pull request, I got `Not Found` error when I tried to create a public gist.